### PR TITLE
Refactor routing in OTP field component

### DIFF
--- a/src/app/(auth)/components/otp_field.tsx
+++ b/src/app/(auth)/components/otp_field.tsx
@@ -160,7 +160,7 @@ export default function OtpField({ id }: { id: string }) {
           },
         })
         router.refresh()
-        router.push('/dashboard')
+        return router.push('/dashboard')
       } else {
         if (responseCode === 200) {
           setUserInLocal({
@@ -175,17 +175,12 @@ export default function OtpField({ id }: { id: string }) {
             },
           })
           router.refresh()
-          router.push('/dashboard')
+          return router.push('/dashboard')
         }
       }
     }
   }
 
-  // React.useEffect(() => {
-  //   if (user) {
-  //     router.push('/dashboard')
-  //   }
-  // }, [user])
   return (
     <>
       <div className="grid w-full items-center justify-center text-center md:min-w-max">


### PR DESCRIPTION
The navigation in the OTP field component has been refactored. Return statements have been added in place of direct use of router.push function for better control flow. The unused React useEffect hook commenting out the router.push has also been removed.